### PR TITLE
Use v1 of license report check

### DIFF
--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate license report 📜
-        uses: insightsengineering/r-license-report@v1.0.0
+        uses: insightsengineering/r-license-report@v1
         with:
           regex: "^AGPL.*"


### PR DESCRIPTION
Use v1, which points to the latest version of the license report check.