### PR TITLE
ignore warning on pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,10 +31,10 @@ on:
         required: false
         default: false
         type: boolean
-      allow-pkgdown-warnings:
-        description: Allow pkgdown warnings for build_site function
+      fail-pkgdown-on-warnings:
+        description: Fail the pkgdown workflow if warnings are generated while generating docs
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -79,7 +79,7 @@ jobs:
           if (length(warnings_marker) > 0) {
             cat("⚠ One or more warnings were generated during the pkgdown build:\n")
             cat(logs[warnings_marker[[1]]:length(logs)], sep = "\n")
-            stop("Please 🙏 fix the warnings shown below this message 👇")
+            #stop("Please 🙏 fix the warnings shown below this message 👇")
           }
           if (length(error_marker) > 0) {
             cat("☠ One or more errors were generated during the pkgdown build:\n")

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         default: false
         type: boolean
+      allow-pkgdown-warnings:
+        description: Allow pkgdown warnings for build_site function
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   pkgdown:
@@ -79,7 +84,10 @@ jobs:
           if (length(warnings_marker) > 0) {
             cat("⚠ One or more warnings were generated during the pkgdown build:\n")
             cat(logs[warnings_marker[[1]]:length(logs)], sep = "\n")
-            #stop("Please 🙏 fix the warnings shown below this message 👇")
+            if ("${{ inputs.allow-pkgdown-warnings }}" == "false")
+            {
+              stop("Please 🙏 fix the warnings shown below this message 👇")
+            }
           }
           if (length(error_marker) > 0) {
             cat("☠ One or more errors were generated during the pkgdown build:\n")

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -84,9 +84,11 @@ jobs:
           if (length(warnings_marker) > 0) {
             cat("⚠ One or more warnings were generated during the pkgdown build:\n")
             cat(logs[warnings_marker[[1]]:length(logs)], sep = "\n")
-            if ("${{ inputs.allow-pkgdown-warnings }}" == "false")
-            {
-              stop("Please 🙏 fix the warnings shown below this message 👇")
+            warn_msg <- "Please 🙏 fix the warnings shown below this message 👇"
+            if ("${{ inputs.fail-pkgdown-on-warnings }}" == "true") {
+              stop(warn_msg)
+            } else {
+              print(warn_msg)
             }
           }
           if (length(error_marker) > 0) {


### PR DESCRIPTION
If readme.md has images, then `pkgdown` will produce warning message and Github action for `Pkgdown Docs` will fail.
This error is only for rocker 4.1.2 with `pkgdown` ver.2.0.1.
Prev. ver. is (pkgdown 1.6/rocker_4.1.0) is ok.
For now, we are ignoring these warnings.

