### PR TITLE
Remove .0 on the end of version

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -36,7 +36,13 @@ jobs:
         shell: Rscript {0}
 
       - name: Remove ending .0 version
-        run: desc::desc_set_version(gsub(".0$", "", desc::desc_get_version()))
+        run: |
+          get_version_components <- function(x) {
+            as.numeric(strsplit(format(x), "[-\\.]")[[1]])
+          }
+          ver_str <- desc::desc_get_version()
+          ver <- get_version_components(ver_str)
+          if (length(ver) > 3) desc::desc_set_version(gsub(".0$", "", ver_str ))
         shell: Rscript {0}
 
       - name: Bump version in NEWS.md 📰

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -35,6 +35,10 @@ jobs:
         run: desc::desc_bump_version(5, normalize = TRUE)
         shell: Rscript {0}
 
+      - name: Remove ending .0 version
+        run: desc::desc_set_version(gsub(".0$", "", desc::desc_get_version()))
+        shell: Rscript {0}
+
       - name: Bump version in NEWS.md 📰
         run: |
           DESC_VERSION=$(R --slave -e 'cat(paste(desc::desc_get_version()))')


### PR DESCRIPTION
https://github.com/insightsengineering/idr-tasks/issues/207

backgroud:

```
# how it's working:
> desc::desc_bump_version(5)
Package version bumped from ‘0.10.0.9056’ to ‘0.10.0.9056.1’
....
```

```
# how it's working on dev part:
> desc::desc_bump_version("dev")
Package version bumped from ‘0.10.0.9056.1’ to ‘0.10.0.9057.0’
```

Remove latest part -> `0.10.0.9057`
