### PR TITLE
Update validator to install dev deps with no update

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -54,8 +54,6 @@ jobs:
 
       - name: Build report 🏗
         uses: insightsengineering/thevalidatoR@v1.1.2
-        with:
-          disable_install_dev_deps: true
 
       - name: Upload report for review ⬆
         if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
https://github.com/insightsengineering/idr-tasks/issues/211

It's needed to set authentycatoin. Dependencies has `update="never"`, so not updating any existing packages. Tested `teal.modules.clinical` and `tern` and looks like it's solves issue with git2r