### PR TITLE
escape a dot

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -42,7 +42,7 @@ jobs:
           }
           ver_str <- desc::desc_get_version()
           ver <- get_version_components(ver_str)
-          if (length(ver) > 3) desc::desc_set_version(gsub(".0$", "", ver_str ))
+          if (length(ver) > 3) desc::desc_set_version(gsub("[.]0$", "", ver_str ))
         shell: Rscript {0}
 
       - name: Bump version in NEWS.md 📰


### PR DESCRIPTION
fixes error observed for `".10"`

```
> gsub(".0$", "", "1.2.3.4.10" )
[1] "1.2.3.4."       # <- incorrect version number
> gsub("[.]0$", "", "1.2.3.4.10" )
[1] "1.2.3.4.10"
> gsub("[.]0$", "", "1.2.3.4.0" )
[1] "1.2.3.4"
```