### PR TITLE
Update style.yaml

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install styler 👚
         run: |
-          if (!require("styler")) install.packages("styler", repos="http://cran.rstudio.com/")
+          devtools::install_github("r-lib/styler")
         shell: Rscript {0}
 
       - name: Run styler 👟


### PR DESCRIPTION
styler package is not updated for a long time, half a year.
In last time @Polkas and @kpagacz find two important problems with were ALREADY solved on styler main branch (github).
Problems:
- substitute(aa %>% bb, env = list(aa = quote(fun()), )) -> styler was wrongly adding brackets () to aa()
- turn off styler functionality was broken