### PR TITLE
Fix failing check because of unset env var

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -104,6 +104,11 @@ jobs:
 
       - name: Run R CMD check 🏁
         run: |
+          if [ "${{ inputs.R_CHECK_FORCE_SUGGESTS }}" == "" ]
+          then {
+            _R_CHECK_FORCE_SUGGESTS_="FALSE"
+          }
+          fi
           if [[ -z "${{ env.NO_TESTS }}" ]]; then
             R CMD check ${{ env.PKGBUILD }}
           else

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -54,7 +54,7 @@ jobs:
           SD_ENABLE_CHECK: ${{ inputs.enable-staged-dependencies-check }}
 
       - name: Build report 🏗
-        uses: insightsengineering/thevalidatoR@v1.1.2
+        uses: insightsengineering/thevalidatoR@v1
 
       - name: Upload report for review ⬆
         if: github.ref != 'refs/heads/main'


### PR DESCRIPTION
# Pull Request

The `workflow_call` input will be blank by default. Override the value.
