### PR TITLE
new name of r-pkg-validation job

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -71,7 +71,7 @@ jobs:
 
   upload-release-assets:
     name: Upload report to release 🔼
-    needs: r-pkg-validation
+    needs: build-install-check
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #269

```
there is an error
[Invalid workflow file: .github/workflows/validation.yaml#L74](https://github.com/insightsengineering/r.pkg.template/actions/runs/2153379295/workflow)
The workflow is not valid. .github/workflows/validation.yaml (Line: 74, Col: 12): Job 'upload-release-assets' depends on unknown job 'r-pkg-validation'.
```

https://github.com/insightsengineering/r.pkg.template/actions/runs/2153379295