### PR TITLE
Performance and devX optimizations

### DIFF
--- a/.github/workflows/bioccheck.yaml
+++ b/.github/workflows/bioccheck.yaml
@@ -89,45 +89,9 @@ jobs:
 
       - name: Build R package 🏗
         run: |
-          R CMD build ${{ github.event.repository.name }}
+          R CMD build --no-build-vignettes \
+            ${{ github.event.repository.name }}
           echo "PKGBUILD=$(echo *.tar.gz)" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set TESTING_DEPTH ⚙
-        env:
-          COMMIT_NEWEST_MESSAGE: ${{ github.event.head_commit.message }}
-          COMMIT_OLDEST_MESSAGE: ${{ github.event.commits[0].message }}
-        run: |
-          cd ${{ github.event.repository.name }}
-          # set TESTING_DEPTH for PR
-          if [[ ! -z "${GITHUB_HEAD_REF}" ]]; then
-            TESTING_DEPTH=3
-            echo "TESTING_DEPTH=3" >> $GITHUB_ENV
-            COMMIT_NEWEST_MESSAGE=$(git log --format=%B -n 1 ${{ github.event.after }})
-          fi
-          if [[ $COMMIT_NEWEST_MESSAGE == *"[skip tests]"* ]]; then
-            echo "NO_TESTS=1" >> $GITHUB_ENV
-          fi
-          # default TESTING_DEPTH
-          if [[ -z "${TESTING_DEPTH}" ]]; then
-            echo "TESTING_DEPTH=1" >> $GITHUB_ENV
-          fi
-        shell: bash
-
-      - name: Run R CMD check 🏁
-        run: |
-          if [[ -z "${{ env.NO_TESTS }}" ]]; then
-            R CMD check ${{ env.PKGBUILD }}
-          else
-            R CMD check --no-tests ${{ env.PKGBUILD }}
-          fi
-        shell: bash
-        continue-on-error: true
-        env:
-          _R_CHECK_TESTS_NLINES_: 0
-
-      - name: Install R package 🚧
-        run: R CMD INSTALL ${{ env.PKGBUILD }}
         shell: bash
 
       - name: Run BiocCheck ☣️

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -145,12 +145,15 @@ jobs:
         run: |
           check_log <- "${{ github.event.repository.name }}.Rcheck/00check.log"
           if (file.exists(check_log)) {
-            cat("Refer to the 'Run R CMD check 🏁' step to troubleshoot failures reported in this step\n")
-            cat("--------------------------------------------\n")
             x <- tail(readLines(check_log), 1)
-            if (!grepl("^Status", x)) stop("☠ No status line found in R CMD check log")
-            if (grepl("ERROR", x)) stop("❌ R CMD check has errors")
-            if (grepl("WARNING", x)) stop("⚠ R CMD check has warnings")
+            if (grepl("ERROR", x)) {
+              cat(check_log, sep ="\n")
+              stop("❌ R CMD check has errors")
+            }
+            if (grepl("WARNING", x)) {
+              cat(check_log, sep ="\n")
+              stop("⚠ R CMD check has warnings")
+            }
           }
         shell: Rscript {0}
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -81,6 +81,7 @@ jobs:
         shell: bash
 
       - name: Build docs 🏗
+        if: github.ref != 'refs/heads/main'
         run: |
           repo="${{ github.event.repository.name }}"
           cd $repo
@@ -177,8 +178,8 @@ jobs:
 
       - name: Setup github user 👤
         run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
 
       - name: Push changes, if any 📥
         uses: EndBug/add-and-commit@v7


### PR DESCRIPTION
- [x] Do not run R CMD check in the BiocCheck workflow
- [x] Do not run pkgdown build in when pushing to main, since publishing builds the docs anyway
- [x] Do not build  vignettes when building the package in the BiocCheck workflow
- [x] Closes  https://github.com/insightsengineering/r.pkg.template/issues/73