### PR TITLE
Add GitHub-generated release notes to release description

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,3 +34,4 @@ jobs:
         with:
           body_path: RELEASE_BODY.txt
           token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true


### PR DESCRIPTION
The `generate_release_notes` parameter of `softprops/action-gh-release` allows to utilize GitHub-generated release notes, and to extend the existing release description with additional details, like the list of merged PRs, and the list of contributors to the release.

This part of release notes can be further customized with [`.github/release.yml` file](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration).

[Example of extended release notes](https://github.com/walkowif/tern/releases/tag/v1.0.6) without any additional configuration.