### PR TITLE
Add empty coverage report

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -241,7 +241,6 @@ jobs:
         continue-on-error: true
 
       - name: Upload report 🔼
-        if: steps.check_coverage_reports.outputs.files_exists == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: coverage-report
@@ -253,8 +252,7 @@ jobs:
       - name: Set output ⚙️
         id: coverage-output
         if: >-
-          steps.check_coverage_reports.outputs.files_exists == 'true'
-            && github.event_name != 'pull_request'
+          github.event_name != 'pull_request'
             && inputs.publish-coverage-report-gh-pages == true
         run: echo "coverage-upload=true" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
In case coverage report isn't generated properly, we want to add a simple message to documentation informing that there's no coverage report instead of 404 error.