### PR TITLE
Typo in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,9 +42,9 @@ For new feature requests, please elaborate on the context and the benefit the fe
 
 ## Pull requests
 
-### Github Flow
+### GitHub Flow
 
-This repository uses the [Github Flow](https://docs.github.com/en/get-started/quickstart/github-flow) model for collaboration. To submit a pull request:
+This repository uses the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) model for collaboration. To submit a pull request:
 
 1. Create a branch
 


### PR DESCRIPTION
Hi @cicdguy - this is small issue, but this looks like this file was copied in all our repositories. Can you merge and propagate the change? The reason for doing that is that our DOCs builds will treat this typo as a spell mistake. For now we specifically need to add Github to inst/WORDLIST file in repositories but it should be resolved by fixing the typo. Thanks!