### PR TITLE
Auto-update dev package version after release is created

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,11 @@ on:
     tags:
       - "v*"
   workflow_call:
+    secrets:
+      REPO_GITHUB_TOKEN:
+        description: |
+          Github token with write access to the repository
+        required: false
   workflow_dispatch:
 
 concurrency:
@@ -20,6 +25,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup token 🔑
+        id: github-token
+        run: |
+          if [ "${{ secrets.REPO_GITHUB_TOKEN }}" == "" ]; then
+            echo "REPO_GITHUB_TOKEN is empty. Substituting it with GITHUB_TOKEN."
+            echo "token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using REPO_GITHUB_TOKEN."
+            echo "token=${{ secrets.REPO_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - name: Checkout repo 🛎
         uses: actions/checkout@v3
 
@@ -33,5 +50,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: RELEASE_BODY.txt
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.github-token.outputs.token }}
           generate_release_notes: true

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -65,18 +65,12 @@ jobs:
         run: if (desc::desc_has_fields("Date")) desc::desc_set("Date", Sys.Date())
         shell: Rscript {0}
 
-      - name: Create new NEWS.md section
-        if: ${{ inputs.vbump-after-release == true }}
-        run: |
-          FIRST_NEWS_LINE=$(head -1 NEWS.md)
-          printf "$FIRST_NEWS_LINE\n\n" | cat - NEWS.md > temp-news.md
-          mv temp-news.md NEWS.md
-
       - name: Bump version in NEWS.md 📰
         run: |
           git config --global --add safe.directory $(pwd)
           DESC_VERSION=$(R --slave -e 'cat(paste(desc::desc_get_version()))')
           NEWS_VERSION=$(awk '/^#+ /{print $3; exit}' NEWS.md)
+          FIRST_NEWS_LINE=$(head -1 NEWS.md)
           sed -i "s/$NEWS_VERSION/$DESC_VERSION/" NEWS.md
           NEWS_VERSION=$(awk '/^#+ /{print $3; exit}' NEWS.md)
           echo "Updated NEWS.md version: $NEWS_VERSION"
@@ -84,6 +78,10 @@ jobs:
             echo "🙈 Updated NEWS.md and DESCRIPTION have different versions!"
             echo "Please ensure that the versions in the NEWS.md and DESCRIPTION are the same 🙏"
             exit 1
+          fi
+          if [ "${{ inputs.vbump-after-release }}" == "true" ]; then
+            printf "$FIRST_NEWS_LINE\n\n" | cat - NEWS.md > temp-news.md
+            mv temp-news.md NEWS.md
           fi
           echo "NEW_PKG_VERSION=${DESC_VERSION}" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -71,17 +71,19 @@ jobs:
           DESC_VERSION=$(R --slave -e 'cat(paste(desc::desc_get_version()))')
           NEWS_VERSION=$(awk '/^#+ /{print $3; exit}' NEWS.md)
           FIRST_NEWS_LINE=$(head -1 NEWS.md)
-          sed -i "s/$NEWS_VERSION/$DESC_VERSION/" NEWS.md
+          if [ "${{ inputs.vbump-after-release }}" == "true" ]; then
+            # Add a new section with the released version that will be vbumped below.
+            printf "$FIRST_NEWS_LINE\n\n" | cat - NEWS.md > temp-news.md
+            mv temp-news.md NEWS.md
+          fi
+          # Replace only the first occurence of $NEWS_VERSION.
+          sed -i "0,/$NEWS_VERSION/s/$NEWS_VERSION/$DESC_VERSION/" NEWS.md
           NEWS_VERSION=$(awk '/^#+ /{print $3; exit}' NEWS.md)
           echo "Updated NEWS.md version: $NEWS_VERSION"
           if (test $DESC_VERSION != $NEWS_VERSION ); then
             echo "🙈 Updated NEWS.md and DESCRIPTION have different versions!"
             echo "Please ensure that the versions in the NEWS.md and DESCRIPTION are the same 🙏"
             exit 1
-          fi
-          if [ "${{ inputs.vbump-after-release }}" == "true" ]; then
-            printf "$FIRST_NEWS_LINE\n\n" | cat - NEWS.md > temp-news.md
-            mv temp-news.md NEWS.md
           fi
           echo "NEW_PKG_VERSION=${DESC_VERSION}" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      vbump-after-release:
+        description: Whether the vbump workflow is running after a release has been published
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: vbump-${{ github.event.pull_request.number || github.ref }}
@@ -52,7 +57,7 @@ jobs:
           token: ${{ steps.github-token.outputs.token }}
 
       - name: Bump version in DESCRIPTION 📜
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.vbump-after-release == true }}
         run: desc::desc_bump_version("dev", normalize = TRUE)
         shell: Rscript {0}
 

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -110,7 +110,7 @@ jobs:
           python -m pip -q install pre-commit
           pre-commit autoupdate
 
-      - name: Checkout to main
+      - name: Checkout to main 🛎
         if: ${{ inputs.vbump-after-release == true }}
         run: |
           git fetch origin main

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -65,6 +65,13 @@ jobs:
         run: if (desc::desc_has_fields("Date")) desc::desc_set("Date", Sys.Date())
         shell: Rscript {0}
 
+      - name: Create new NEWS.md section
+        if: ${{ inputs.vbump-after-release == true }}
+        run: |
+          FIRST_NEWS_LINE=$(head -1 NEWS.md)
+          printf "$FIRST_NEWS_LINE\n\n" | cat - NEWS.md > temp-news.md
+          mv temp-news.md NEWS.md
+
       - name: Bump version in NEWS.md 📰
         run: |
           git config --global --add safe.directory $(pwd)

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -103,6 +103,11 @@ jobs:
           python -m pip -q install pre-commit
           pre-commit autoupdate
 
+      - name: Checkout to main
+        if: ${{ inputs.vbump-after-release == true }}
+        run: |
+          git checkout main
+
       - name: Commit and push changes 📌
         if: ${{ env.NEW_PKG_VERSION }}
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -106,7 +106,9 @@ jobs:
       - name: Checkout to main
         if: ${{ inputs.vbump-after-release == true }}
         run: |
+          git fetch origin main
           git checkout main
+          git pull origin main
 
       - name: Commit and push changes 📌
         if: ${{ env.NEW_PKG_VERSION }}


### PR DESCRIPTION
Changes to:
* `release.yaml` - it's necessary to enable using custom (`insightsengineering`) PAT in order to create the GitHub release. The reason is: when using `GITHUB_TOKEN`, the creation of release will not trigger any workflows in order to avoid recursive invocations of workflows.
* `version-bump.yaml` - when a new `vbump-after-release` input is specified, package version will be bumped, and a new section in `NEWS.md` will be created.