### PR TITLE
Fix NOTE blocklist processing

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -634,11 +634,11 @@ jobs:
               print("Checking notes...")
               regexes <- "${{ inputs.note-blocklist }}"
               regexes <- unlist(strsplit(regexes, split = "\n"))
-              lines <- paste(readLines(check_log), collapse = " ")
+              lines <- paste(readLines(check_log), collapse = "\n")
               notes_result <- vapply(
                 regexes,
                 function(r){
-                  if (grepl(r, lines)) {
+                  if (grepl(paste0(r, "\n"), lines, perl=T)) {
                     print(r)
                     return(TRUE)
                   }


### PR DESCRIPTION
This fix is required for the NOTE blocklist to match strings like: `checking R code for possible problems .* NOTE` where `NOTE` occurs at the end of the line.
Otherwise any input lines starting with string `checking R code for possible problems` will match the blocklist entry.
