### PR TITLE
Add package subdirectory input

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -14,6 +14,12 @@ on:
       - main
   workflow_dispatch:
   workflow_call:
+    inputs:
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 jobs:
   audit:
@@ -52,6 +58,7 @@ jobs:
             }
           )
         shell: Rscript {0}
+        working-directory: ${{ inputs.package-subdirectory }}
 
       - name: Run oysteR scan on renv.lock 🔒
         run: |

--- a/.github/workflows/bioccheck.yaml
+++ b/.github/workflows/bioccheck.yaml
@@ -48,6 +48,11 @@ on:
         required: false
         type: string
         default: upstream
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: bioccheck-${{ github.event.pull_request.number || github.ref }}
@@ -121,6 +126,6 @@ jobs:
       - name: Run BiocCheck ☣️
         uses: insightsengineering/bioc-check-action@v1
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           no-check-version-num: true
           allow-failure: ${{ inputs.allow-failure }}

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -150,7 +150,7 @@ on:
         description: Subdirectory in the repository, where the R package is located.
         required: false
         type: string
-        default: "."
+        default: ""
 
 concurrency:
   group: r-cmd-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -146,6 +146,11 @@ on:
         required: false
         type: string
         default: "release-candidate"
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: r-cmd-${{ github.event.pull_request.number || github.ref }}
@@ -299,7 +304,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}
@@ -315,7 +320,7 @@ jobs:
             x <- desc::desc_set_dep("xml2", "Suggests")
           }
         shell: Rscript {0}
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Replace testthat.R for test reporting 🎚
         if: inputs.disable-unit-test-reports != 'true'
@@ -337,7 +342,7 @@ jobs:
           cat tests/testthat.R
           fi
         shell: bash
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Build R package 🏗
         run: |
@@ -350,6 +355,7 @@ jobs:
           R CMD build ${{ github.event.repository.name }}
           echo "PKGBUILD=$(echo ${{ github.event.repository.name }}_*.tar.gz)" >> $GITHUB_ENV
         shell: bash
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Set TESTING_DEPTH ⚙
         env:
@@ -370,7 +376,7 @@ jobs:
             echo "TESTING_DEPTH=1" >> $GITHUB_ENV
           fi
         shell: bash
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Run R CMD check 🏁
         run: |
@@ -405,12 +411,16 @@ jobs:
           }
           EOF
           R CMD check ${ADDITIONAL_PARAMS} ${{ env.PKGBUILD }}
+          # TODO debug
+          pwd
+          ls -la
         shell: bash
         continue-on-error: true
         env:
           _R_CHECK_TESTS_NLINES_: 0
           _R_CHECK_VIGNETTES_NLINES_: 0
           _R_CHECK_FORCE_SUGGESTS_: ${{ inputs.R_CHECK_FORCE_SUGGESTS }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Fetch report from ${{ env.junit_xml_storage }} ⤵️
         if: env.junit_xml_comparison == 'true'

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -697,7 +697,7 @@ jobs:
           R CMD build .
           echo "PKGBUILD=$(echo ${{ github.event.repository.name }}_*.tar.gz)" >> $GITHUB_ENV
         shell: bash
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Upload package build ⤴
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -352,10 +352,9 @@ jobs:
             export $(tr '\n' ' ' < /tmp/dotenv.env)
           }
           fi
-          R CMD build ${{ github.event.repository.name }}
+          R CMD build ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           echo "PKGBUILD=$(echo ${{ github.event.repository.name }}_*.tar.gz)" >> $GITHUB_ENV
         shell: bash
-        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Set TESTING_DEPTH ⚙
         env:

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -700,7 +700,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ github.event.repository.name }}/${{ env.PKGBUILD }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/${{ env.PKGBUILD }}
           name: ${{ env.PKGBUILD }}
 
   publish-junit-html-report:

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -410,9 +410,6 @@ jobs:
           }
           EOF
           R CMD check ${ADDITIONAL_PARAMS} ${{ env.PKGBUILD }}
-          # TODO debug
-          pwd
-          ls -la
         shell: bash
         continue-on-error: true
         env:

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -419,7 +419,6 @@ jobs:
           _R_CHECK_TESTS_NLINES_: 0
           _R_CHECK_VIGNETTES_NLINES_: 0
           _R_CHECK_FORCE_SUGGESTS_: ${{ inputs.R_CHECK_FORCE_SUGGESTS }}
-        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Fetch report from ${{ env.junit_xml_storage }} ⤵️
         if: env.junit_xml_comparison == 'true'

--- a/.github/workflows/grammar.yaml
+++ b/.github/workflows/grammar.yaml
@@ -89,7 +89,7 @@ jobs:
               passiveVoice = false;
             }
             files.forEach((file) => {
-              if (fs.lstatSync(file).isFile() && 
+              if (fs.lstatSync(file).isFile() &&
                   !path.dirname(file).startsWith("node_modules")) {
                 const contents = fs.readFileSync(file, 'utf8');
                 const suggestions = writeGood(contents, { passive : passiveVoice });

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -14,6 +14,12 @@ on:
       - main
   workflow_dispatch:
   workflow_call:
+    inputs:
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: licenses-${{ github.event.pull_request.number || github.ref }}
@@ -34,3 +40,4 @@ jobs:
         uses: insightsengineering/r-license-report@v1
         with:
           regex: "^AGPL.*"
+        working-directory: ${{ inputs.package-subdirectory }}

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -40,4 +40,4 @@ jobs:
         uses: insightsengineering/r-license-report@v1
         with:
           regex: "^AGPL.*"
-        working-directory: ${{ inputs.package-subdirectory }}
+          path: ${{ inputs.package-subdirectory }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -106,6 +106,11 @@ on:
         type: string
         default: >-
           ^main$|^devel$|^pre-release$|^latest-tag$|^release-candidate$|^develop$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)(-rc[0-9]+)$
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: docs-${{ github.event.pull_request.number || github.ref }}
@@ -163,7 +168,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}
@@ -173,7 +178,7 @@ jobs:
           if (file.exists("renv.lock")) renv::restore()
           install.packages(".", repos=NULL, type="source")
         shell: Rscript {0}
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Build docs 🏗
         if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
@@ -201,12 +206,12 @@ jobs:
           }
           fi
         shell: bash
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Create documentation artifact 📂
         if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
         run: |
-          pushd ${{ github.event.repository.name }}/docs/
+          pushd ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/docs/
           zip -r9 $OLDPWD/pkgdown.zip *
           popd
         shell: bash
@@ -239,7 +244,7 @@ jobs:
           )
           EOF
         shell: bash
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
   multi-version-docs:
     name: Multi-version docs 📑
@@ -261,7 +266,7 @@ jobs:
       - name: Create and publish docs ↗️
         uses: insightsengineering/r-pkgdown-multiversion@v2
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           default-landing-page: ${{ inputs.default-landing-page }}
           refs-order: ${{ inputs.refs-order }}
           latest-tag-alt-name: ${{ inputs.latest-tag-alt-name }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -266,7 +266,7 @@ jobs:
       - name: Create and publish docs ↗️
         uses: insightsengineering/r-pkgdown-multiversion@v2
         with:
-          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
+          path: ${{ github.event.repository.name }}
           default-landing-page: ${{ inputs.default-landing-page }}
           refs-order: ${{ inputs.refs-order }}
           latest-tag-alt-name: ${{ inputs.latest-tag-alt-name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         default: false
         type: boolean
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
   workflow_dispatch:
 
 concurrency:
@@ -68,6 +73,7 @@ jobs:
           RELEASE_VERSION=$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION)
           REPOSITORY_NAME="${{ github.event.repository.name }}"
           (awk "/^#+.*${REPOSITORY_NAME//./\.}.*${RELEASE_VERSION//./\.}$/{flag=1;next}/^#+.*${REPOSITORY_NAME//./\.}.*/{flag=0}flag" NEWS.md | grep -v "^$" || echo "* ${RELEASE_VERSION}") > RELEASE_BODY.txt
+        working-directory: ${{ inputs.package-subdirectory }}
 
       - name: Create release 🌟
         if: >-
@@ -75,6 +81,6 @@ jobs:
             inputs.create-rc-releases == true
         uses: softprops/action-gh-release@v1
         with:
-          body_path: RELEASE_BODY.txt
+          body_path: ${{ inputs.package-subdirectory }}/RELEASE_BODY.txt
           token: ${{ steps.github-token.outputs.token }}
           generate_release_notes: true

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
         default: upstream
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
     secrets:
       REPO_GITHUB_TOKEN:
         description: |
@@ -99,7 +104,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}
@@ -127,7 +132,7 @@ jobs:
             stop("Please 🙏 fix the errors shown below this message 👇")
           }
         shell: Rscript {0}
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Roxygen check 🅾
         run: |
@@ -170,4 +175,4 @@ jobs:
           }
           fi
         shell: bash
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -50,4 +50,4 @@ jobs:
         uses: insightsengineering/r-spellcheck-action@v2
         with:
           exclude: inst/extdata/*
-          path: ${{ env.package-subdirectory }}
+          path: ${{ env.package_subdirectory }}

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -40,8 +40,14 @@ jobs:
       - name: Checkout Code 🛎
         uses: actions/checkout@v3
 
+      - name: Normalize variables 📏
+        run: |
+          package_subdirectory_input="${{ inputs.package-subdirectory }}"
+          echo "package_subdirectory=${package_subdirectory_input:-.}" >> $GITHUB_ENV
+        shell: bash
+
       - name: Run Spellcheck 👟
         uses: insightsengineering/r-spellcheck-action@v2
         with:
           exclude: inst/extdata/*
-          path: ${{ inputs.package-subdirectory }}
+          path: ${{ env.package-subdirectory }}

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -15,6 +15,12 @@ on:
       - main
   workflow_dispatch:
   workflow_call:
+    inputs:
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: spelling-${{ github.event.pull_request.number || github.ref }}
@@ -38,3 +44,4 @@ jobs:
         uses: insightsengineering/r-spellcheck-action@v2
         with:
           exclude: inst/extdata/*
+          path: ${{ inputs.package-subdirectory }}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -21,6 +21,11 @@ on:
         required: false
         default: false
         type: boolean
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: style-${{ github.event.pull_request.number || github.ref }}
@@ -90,7 +95,7 @@ jobs:
             )
           }
         shell: Rscript {0}
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Check file existence 🤔
         id: check_files
@@ -120,7 +125,7 @@ jobs:
           git push -v origin HEAD:${{ steps.branch-name.outputs.head_ref_branch }} || \
             echo "⚠️ Could not push to ${BRANCH_NAME} on $(git remote -v show -n origin | grep Push)"
         shell: bash
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
         continue-on-error: true
 
       - name: Styler check summary 🅾

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -77,6 +77,11 @@ on:
         required: false
         type: string
         default: "release-candidate"
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
     secrets:
       REPO_GITHUB_TOKEN:
         description: |
@@ -186,7 +191,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.REPO_GITHUB_TOKEN }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}//${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}
@@ -196,7 +201,7 @@ jobs:
           if (file.exists("renv.lock")) renv::restore()
           install.packages(".", repos=NULL, type="source")
         shell: Rscript {0}
-        working-directory: ${{ github.event.repository.name }}
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Install covr 🎪
         run: |
@@ -209,7 +214,7 @@ jobs:
 
       - name: Run coverage 👟
         run: |
-          setwd("${{ github.event.repository.name }}")
+          setwd("${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}")
           if (file.exists("renv.lock")) {
             renv::restore()
           }
@@ -259,15 +264,15 @@ jobs:
         uses: andstor/file-existence-action@v2
         with:
           files: >-
-            ${{ github.event.repository.name }}/coverage.xml,
-            ${{ github.event.repository.name }}/coverage.txt,
-            ${{ github.event.repository.name }}/coverage-report.html
+            ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/coverage.xml,
+            ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/coverage.txt,
+            ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/coverage-report.html
 
       - name: Post coverage report 🗞
         if: steps.check_coverage_reports.outputs.files_exists == 'true'
         uses: insightsengineering/coverage-action@v2
         with:
-          path: ${{ github.event.repository.name }}/coverage.xml
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/coverage.xml
           threshold: 80
           fail: false
           publish: ${{ inputs.publish-coverage-report }}
@@ -279,8 +284,8 @@ jobs:
         with:
           name: coverage-report
           path: |
-            ${{ github.event.repository.name }}/coverage-report.html
-            ${{ github.event.repository.name }}/lib/
+            ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/coverage-report.html
+            ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/lib/
         continue-on-error: true
 
       - name: Set output ⚙️
@@ -321,7 +326,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}
@@ -331,7 +336,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           allow-failure: ${{ inputs.allow-failure }}
 
   publish-coverage-report:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -81,7 +81,7 @@ on:
         description: Subdirectory in the repository, where the R package is located.
         required: false
         type: string
-        default: "."
+        default: ""
     secrets:
       REPO_GITHUB_TOKEN:
         description: |
@@ -191,7 +191,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.REPO_GITHUB_TOKEN }}
         with:
-          path: ${{ github.event.repository.name }}//${{ inputs.package-subdirectory }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -105,7 +105,7 @@ jobs:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
           report_output_prefix: validation_report
-          report_pkg_dir: ${{ inputs.package-subdirectory }}
+          report_pkg_dir: ${{ env.package_subdirectory }}
 
       - name: Upload report for review ⬆
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -88,7 +88,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
+          path: ${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -77,6 +77,12 @@ jobs:
       - name: Checkout repo 🛎
         uses: actions/checkout@v3
 
+      - name: Normalize variables 📏
+        run: |
+          package_subdirectory_input="${{ inputs.package-subdirectory }}"
+          echo "package_subdirectory=${package_subdirectory_input:-.}" >> $GITHUB_ENV
+        shell: bash
+
       - name: Restore SD cache 💰
         uses: actions/cache@v3
         with:
@@ -88,7 +94,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ inputs.package-subdirectory }}
+          path: ${{ env.package_subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: upstream
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
     secrets:
       REPO_GITHUB_TOKEN:
         description: |
@@ -83,6 +88,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}
@@ -93,6 +99,7 @@ jobs:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
           report_output_prefix: validation_report
+          report_pkg_dir: ${{ inputs.package-subdirectory }}
 
       - name: Upload report for review ⬆
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -119,8 +119,7 @@ jobs:
           inputs.disable-precommit-autoupdate != 'true' &&
             steps.precommit-config-exists.outputs.files_exists == 'true'
         run: |
-          pwd
-          ls -la
+          git config --global --add safe.directory $(pwd)
           python -m pip -q install pre-commit
           pre-commit autoupdate || true
           cat /github/home/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -60,10 +60,12 @@ jobs:
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.vbump-after-release == true }}
         run: desc::desc_bump_version("dev", normalize = TRUE)
         shell: Rscript {0}
+        working-directory: ${{ inputs.package-subdirectory }}
 
       - name: Update Date field 📅
         run: if (desc::desc_has_fields("Date")) desc::desc_set("Date", Sys.Date())
         shell: Rscript {0}
+        working-directory: ${{ inputs.package-subdirectory }}
 
       - name: Bump version in NEWS.md 📰
         run: |
@@ -91,6 +93,7 @@ jobs:
           }
           fi
         shell: bash
+        working-directory: ${{ inputs.package-subdirectory }}
 
       - name: Check if a pre-commit config exists
         id: precommit-config-exists

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -130,12 +130,22 @@ jobs:
           git checkout main
           git pull origin main
 
+      - name: Set file pattern to commit
+        id: file-pattern
+        run: |
+          if [[ "${{ inputs.package-subdirectory }}" == "." ]]; then
+            FILE_PATTERN="NEWS.md DESCRIPTION"
+          else
+            FILE_PATTERN="${{ inputs.package-subdirectory }}/NEWS.md ${{ inputs.package-subdirectory }}/DESCRIPTION"
+          fi
+          echo "file-pattern=$FILE_PATTERN" >> $GITHUB_OUTPUT
+
       - name: Commit and push changes 📌
         if: ${{ env.NEW_PKG_VERSION }}
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "[skip actions] Bump version to ${{ env.NEW_PKG_VERSION }}"
-          file_pattern: NEWS.md DESCRIPTION .pre-commit-config.yaml
+          file_pattern: "${{ steps.file-pattern.outputs.file-pattern }} .pre-commit-config.yaml"
           commit_user_name: insights-engineering-bot
           commit_user_email: >-
             68416928+insights-engineering-bot@users.noreply.github.com

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -22,6 +22,11 @@ on:
         required: false
         default: false
         type: boolean
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: vbump-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -122,7 +122,8 @@ jobs:
           pwd
           ls -la
           python -m pip -q install pre-commit
-          pre-commit autoupdate
+          pre-commit autoupdate || true
+          cat /github/home/.cache/pre-commit/pre-commit.log
 
       - name: Checkout to main 🛎
         if: ${{ inputs.vbump-after-release == true }}

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -130,7 +130,7 @@ jobs:
           git checkout main
           git pull origin main
 
-      - name: Set file pattern to commit
+      - name: Set file pattern to commit ⚙️
         id: file-pattern
         run: |
           if [[ "${{ inputs.package-subdirectory }}" == "." ]]; then

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -119,6 +119,8 @@ jobs:
           inputs.disable-precommit-autoupdate != 'true' &&
             steps.precommit-config-exists.outputs.files_exists == 'true'
         run: |
+          pwd
+          ls -la
           python -m pip -q install pre-commit
           pre-commit autoupdate
 

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -139,6 +139,7 @@ jobs:
             FILE_PATTERN="${{ inputs.package-subdirectory }}/NEWS.md ${{ inputs.package-subdirectory }}/DESCRIPTION"
           fi
           echo "file-pattern=$FILE_PATTERN" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Commit and push changes 📌
         if: ${{ env.NEW_PKG_VERSION }}

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -121,8 +121,7 @@ jobs:
         run: |
           git config --global --add safe.directory $(pwd)
           python -m pip -q install pre-commit
-          pre-commit autoupdate || true
-          cat /github/home/.cache/pre-commit/pre-commit.log
+          pre-commit autoupdate
 
       - name: Checkout to main 🛎
         if: ${{ inputs.vbump-after-release == true }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -15,6 +15,12 @@ on:
       - main
   workflow_dispatch:
   workflow_call:
+    inputs:
+      package-subdirectory:
+        description: Subdirectory in the repository, where the R package is located.
+        required: false
+        type: string
+        default: "."
 
 concurrency:
   group: version-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -45,6 +45,7 @@ jobs:
               exit 1
           fi
         shell: bash
+        working-directory: ${{ inputs.package-subdirectory }}
 
   emoji:
     name: Emoji in NEWS.md 📰
@@ -84,3 +85,4 @@ jobs:
               sys.exit(1)
           print("🥰 No emojis found in the NEWS.md, good to go!")
         shell: python
+        working-directory: ${{ inputs.package-subdirectory }}


### PR DESCRIPTION
Add `package-subdirectory` input to selected workflows to allow running the workflows for repositories where R packages are stored in a subdirectory within the repository.