### PR TITLE
Update strategies on R min deps check workflow

### DIFF
--- a/.github/workflows/verdepcheck.yaml
+++ b/.github/workflows/verdepcheck.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       strategy:
         description: |
-          Strategy to test package dependencies. One of: min, release, max.
+          Strategy to test package dependencies. One of: min_isolate, min_cohort, release, max.
         required: true
         type: string
       additional-env-vars:
@@ -74,7 +74,7 @@ jobs:
 
       - name: Dependency Test - ${{ env.strategy }} 🔢
         id: verdepcheck
-        uses: insightsengineering/r-verdepcheck-action@main
+        uses: insightsengineering/r-verdepcheck-action@new-strategies
         with:
           github-token: ${{ steps.github-token.outputs.token }}
           check-args: ${{ inputs.check-args }}

--- a/.github/workflows/verdepcheck.yaml
+++ b/.github/workflows/verdepcheck.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Dependency Test - ${{ env.strategy }} 🔢
         id: verdepcheck
-        uses: insightsengineering/r-verdepcheck-action@new-strategies
+        uses: insightsengineering/r-verdepcheck-action@main
         with:
           github-token: ${{ steps.github-token.outputs.token }}
           check-args: ${{ inputs.check-args }}


### PR DESCRIPTION
WIP :: parent issue: https://github.com/insightsengineering/nestdevs-tasks/issues/7

### 🔴 What's needed before merging?

This PR depends on some upstream changes that need to be finalized before being ready to review.

#### Change in code

- [x] Change branch in verdepcheck-action from `new-strategies` back to `@main`

#### PRS

- [x] verdepcheck
  * https://github.com/insightsengineering/verdepcheck/pull/24
  * https://github.com/insightsengineering/verdepcheck/pull/26
- [x] verdepcheck-action
  * https://github.com/insightsengineering/r-verdepcheck-action/pull/16

### Changes description

* Documentation update on strategy, replacing `min` with `min_isolate` and `min_cohort`