### PR TITLE
Wordlist reduction

### DIFF
--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -60,7 +60,7 @@ jobs:
           y <- readLines('inst/WORDLIST')
           if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
             message("Unnecessary entries on WORDLIST:")
-            message(setdiff(x, y))
+            message(cat(setdiff(x, y), sep='\n'))
           }
         shell: Rscript {0}
 

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -52,11 +52,6 @@ jobs:
           exclude: inst/extdata/*
           path: ${{ env.package_subdirectory }}
 
-      - name: git safe directory 🦺
-        if: github.event_name == 'push'
-        run: |
-          git config --global --add safe.directory $(pwd)
-
       - name: Clean up WORDLIST 🧼
         if: github.event_name == 'push'
         run: |
@@ -74,6 +69,7 @@ jobs:
       - name: Checkout to main 🛎
         if: github.event_name == 'push'
         run: |
+          git config --global --add safe.directory $(pwd)
           git fetch origin main
           git checkout main
           git pull origin main

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -52,7 +52,7 @@ jobs:
           exclude: inst/extdata/*
           path: ${{ env.package_subdirectory }}
 
-      - name: Clean up WORDLIST 🫧
+      - name: Clean up WORDLIST 🧼
         run: |
           x <- readLines('inst/WORDLIST')
           file.remove('inst/WORDLIST')

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -51,3 +51,25 @@ jobs:
         with:
           exclude: inst/extdata/*
           path: ${{ env.package_subdirectory }}
+
+      - name: Clean up WORDLIST
+        run: |
+          x <- readLines('inst/WORDLIST')
+          file.remove('inst/WORDLIST')
+          spelling::update_wordlist(confirm = FALSE)
+          y <- readLines('inst/WORDLIST')
+          if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
+            message("Unnecessary entries on WORDLIST:")
+            message(setdiff(x, y))
+          }
+        shell: Rscript {0}
+
+      - name: Commit and push changes 📌
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "[skip actions] Update WORDLIST"
+          file_pattern: "inst/WORDLIST"
+          commit_user_name: insights-engineering-bot
+          commit_user_email: >-
+            68416928+insights-engineering-bot@users.noreply.github.com
+        continue-on-error: true

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -64,6 +64,10 @@ jobs:
           }
         shell: Rscript {0}
 
+      - name: git safe directory
+        run: |
+          git config --global --add safe.directory $(pwd)
+
       - name: Commit and push changes 📌
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -54,6 +54,7 @@ jobs:
           git config --global --add safe.directory $(pwd)
 
       - name: Clean up WORDLIST 🧼
+        if: github.event_name == 'push'
         run: |
           x <- readLines('inst/WORDLIST')
           file.remove('inst/WORDLIST')
@@ -66,7 +67,15 @@ jobs:
           }
         shell: Rscript {0}
 
+      - name: Checkout to main 🛎
+        if: github.event_name == 'push'
+        run: |
+          git fetch origin main
+          git checkout main
+          git pull origin main
+
       - name: Set file pattern to commit ⚙️
+        if: github.event_name == 'push'
         id: file-pattern
         run: |
           if [[ "${{ inputs.package-subdirectory }}" == "." ]]; then

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -52,7 +52,7 @@ jobs:
           exclude: inst/extdata/*
           path: ${{ env.package_subdirectory }}
 
-      - name: Clean up WORDLIST
+      - name: Clean up WORDLIST 🫧
         run: |
           x <- readLines('inst/WORDLIST')
           file.remove('inst/WORDLIST')
@@ -64,7 +64,7 @@ jobs:
           }
         shell: Rscript {0}
 
-      - name: git safe directory
+      - name: git safe directory 🦺
         run: |
           git config --global --add safe.directory $(pwd)
 

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -69,6 +69,7 @@ jobs:
           git config --global --add safe.directory $(pwd)
 
       - name: Commit and push changes 📌
+        if: github.event_name != 'workflow_run'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "[skip actions] Update WORDLIST"

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -22,6 +22,10 @@ on:
         type: string
         default: "."
 
+concurrency:
+  group: spelling-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   spelling:
     name: Check spelling 🔠

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -48,20 +48,6 @@ jobs:
           exclude: inst/extdata/*
           path: ${{ env.package_subdirectory }}
 
-      - name: Clean up WORDLIST 🧼
-        if: github.event_name == 'push'
-        run: |
-          x <- readLines('inst/WORDLIST')
-          file.remove('inst/WORDLIST')
-          spelling::update_wordlist(confirm = FALSE)
-          y <- readLines('inst/WORDLIST')
-          if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
-            Sys.sleep(1)
-            message("Unnecessary entries on WORDLIST:")
-            message(cat(setdiff(x, y), sep='\n'))
-          }
-        shell: Rscript {0}
-
       - name: git safe directory 🦺
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -49,22 +49,26 @@ jobs:
           path: ${{ env.package_subdirectory }}
 
       - name: Clean up WORDLIST 🧼
+        if: github.event_name == 'push'
         run: |
           x <- readLines('inst/WORDLIST')
           file.remove('inst/WORDLIST')
           spelling::update_wordlist(confirm = FALSE)
           y <- readLines('inst/WORDLIST')
           if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
+            Sys.sleep(1)
             message("Unnecessary entries on WORDLIST:")
             message(cat(setdiff(x, y), sep='\n'))
           }
         shell: Rscript {0}
 
       - name: git safe directory 🦺
+        if: github.event_name == 'push'
         run: |
           git config --global --add safe.directory $(pwd)
 
       - name: Commit and push changes 📌
+        if: github.event_name == 'push'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "[skip actions] Update WORDLIST"

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -60,7 +60,6 @@ jobs:
           spelling::update_wordlist(confirm = FALSE)
           y <- readLines('inst/WORDLIST')
           if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
-            Sys.sleep(1)
             message("Unnecessary entries on WORDLIST:")
             message(cat(setdiff(x, y), sep='\n'))
           }

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -22,10 +22,6 @@ on:
         type: string
         default: "."
 
-concurrency:
-  group: spelling-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   spelling:
     name: Check spelling 🔠

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -69,7 +69,6 @@ jobs:
           git config --global --add safe.directory $(pwd)
 
       - name: Commit and push changes 📌
-        if: github.event_name != 'workflow_run'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "[skip actions] Update WORDLIST"

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -66,12 +66,23 @@ jobs:
           }
         shell: Rscript {0}
 
+      - name: Set file pattern to commit ⚙️
+        id: file-pattern
+        run: |
+          if [[ "${{ inputs.package-subdirectory }}" == "." ]]; then
+            FILE_PATTERN="inst/WORDLIST"
+          else
+            FILE_PATTERN="${{ inputs.package-subdirectory }}/inst/WORDLIST"
+          fi
+          echo "file-pattern=$FILE_PATTERN" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Commit and push changes 📌
         if: github.event_name == 'push'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "[skip actions] Update WORDLIST"
-          file_pattern: "inst/WORDLIST"
+          file_pattern: "${{ steps.file-pattern.outputs.file-pattern }}"
           commit_user_name: insights-engineering-bot
           commit_user_email: >-
             68416928+insights-engineering-bot@users.noreply.github.com

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -53,6 +53,19 @@ jobs:
         run: |
           git config --global --add safe.directory $(pwd)
 
+      - name: Clean up WORDLIST 🧼
+        run: |
+          x <- readLines('inst/WORDLIST')
+          file.remove('inst/WORDLIST')
+          spelling::update_wordlist(confirm = FALSE)
+          y <- readLines('inst/WORDLIST')
+          if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
+            Sys.sleep(1)
+            message("Unnecessary entries on WORDLIST:")
+            message(cat(setdiff(x, y), sep='\n'))
+          }
+        shell: Rscript {0}
+
       - name: Commit and push changes 📌
         if: github.event_name == 'push'
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -124,7 +124,6 @@ jobs:
           pre-commit autoupdate
 
       - name: Checkout to main 🛎
-        if: ${{ inputs.vbump-after-release == true }}
         run: |
           git fetch origin main
           git checkout main
@@ -134,9 +133,9 @@ jobs:
         id: file-pattern
         run: |
           if [[ "${{ inputs.package-subdirectory }}" == "." ]]; then
-            FILE_PATTERN="NEWS.md DESCRIPTION inst/WORDLIST"
+            FILE_PATTERN="NEWS.md DESCRIPTION"
           else
-            FILE_PATTERN="${{ inputs.package-subdirectory }}/NEWS.md ${{ inputs.package-subdirectory }}/DESCRIPTION ${{ inputs.package-subdirectory }}/inst/WORDLIST"
+            FILE_PATTERN="${{ inputs.package-subdirectory }}/NEWS.md ${{ inputs.package-subdirectory }}/DESCRIPTION"
           fi
           echo "file-pattern=$FILE_PATTERN" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -125,6 +125,7 @@ jobs:
 
       - name: Clean up WORDLIST 🧼
         run: |
+          install.packages("spelling")
           x <- readLines('inst/WORDLIST')
           file.copy("inst/WORDLIST", "inst/WORDLIST.copy")
           file.remove('inst/WORDLIST')

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -123,21 +123,6 @@ jobs:
           python -m pip -q install pre-commit
           pre-commit autoupdate
 
-      - name: Clean up WORDLIST 🧼
-        run: |
-          install.packages("spelling")
-          x <- readLines('inst/WORDLIST')
-          file.copy("inst/WORDLIST", "inst/WORDLIST.copy")
-          file.remove('inst/WORDLIST')
-          spelling::update_wordlist(confirm = FALSE)
-          y <- readLines('inst/WORDLIST')
-          if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
-            Sys.sleep(1)
-            message("Unnecessary entries on WORDLIST:")
-            message(cat(setdiff(x, y), sep='\n'))
-          }
-        shell: Rscript {0}
-
       - name: Checkout to main 🛎
         if: ${{ inputs.vbump-after-release == true }}
         run: |

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -124,6 +124,7 @@ jobs:
           pre-commit autoupdate
 
       - name: Checkout to main 🛎
+        if: ${{ inputs.vbump-after-release == true }}
         run: |
           git fetch origin main
           git checkout main

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -123,6 +123,20 @@ jobs:
           python -m pip -q install pre-commit
           pre-commit autoupdate
 
+      - name: Clean up WORDLIST 🧼
+        run: |
+          x <- readLines('inst/WORDLIST')
+          file.copy("inst/WORDLIST", "inst/WORDLIST.copy")
+          file.remove('inst/WORDLIST')
+          spelling::update_wordlist(confirm = FALSE)
+          y <- readLines('inst/WORDLIST')
+          if (length(setdiff(y, x)) == 0 && length(setdiff(x, y)) > 0) {
+            Sys.sleep(1)
+            message("Unnecessary entries on WORDLIST:")
+            message(cat(setdiff(x, y), sep='\n'))
+          }
+        shell: Rscript {0}
+
       - name: Checkout to main 🛎
         if: ${{ inputs.vbump-after-release == true }}
         run: |
@@ -134,9 +148,9 @@ jobs:
         id: file-pattern
         run: |
           if [[ "${{ inputs.package-subdirectory }}" == "." ]]; then
-            FILE_PATTERN="NEWS.md DESCRIPTION"
+            FILE_PATTERN="NEWS.md DESCRIPTION inst/WORDLIST"
           else
-            FILE_PATTERN="${{ inputs.package-subdirectory }}/NEWS.md ${{ inputs.package-subdirectory }}/DESCRIPTION"
+            FILE_PATTERN="${{ inputs.package-subdirectory }}/NEWS.md ${{ inputs.package-subdirectory }}/DESCRIPTION ${{ inputs.package-subdirectory }}/inst/WORDLIST"
           fi
           echo "file-pattern=$FILE_PATTERN" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
[Example workflow run removing redundant entries from WORDLIST](https://github.com/walkowif/tern/actions/runs/5729135507/job/15525243131)

[Example commit with entries removed from WORDLIST](https://github.com/walkowif/tern/commit/c5ee9129f59806fdc174f37f537f75786917c10e)

This will require the propagation of removal of [this line](https://github.com/insightsengineering/tern/blob/main/.github/workflows/check.yaml#L66) from repositories where this functionality is supposed to be enabled.

This way the workflow will be configured to remove redundant WORDLIST entries on `main` only.

