### PR TITLE
Fix package version for rc tags

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -333,19 +333,9 @@ jobs:
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Get package name 📦
-        if: startsWith(github.ref, 'refs/tags/v') == false
         run: |
           echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION)_"\
           "$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION).tar.gz)" >> $GITHUB_ENV
-          echo "PKGNAME=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))" >> $GITHUB_ENV
-        shell: bash
-        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
-
-      - name: Get package name (tags) 📦
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))_\
-          ${GITHUB_REF#refs/*/v}.tar.gz" >> $GITHUB_ENV
           echo "PKGNAME=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))" >> $GITHUB_ENV
         shell: bash
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
@@ -823,13 +813,10 @@ jobs:
       - name: Checkout repo 🛎
         uses: actions/checkout@v3
 
-      - name: Set release version and package build filename 📐
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-
       - name: Get package build filename 📦
         run: |
-          echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))_\
-          ${{ env.RELEASE_VERSION }}.tar.gz" >> $GITHUB_ENV
+          echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))_"\
+          "$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION).tar.gz" >> $GITHUB_ENV
         shell: bash
 
       - name: Download artifact ⏬

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -815,8 +815,8 @@ jobs:
 
       - name: Get package build filename 📦
         run: |
-          echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))_"\
-          "$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION).tar.gz" >> $GITHUB_ENV
+          echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION)_"\
+          "$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION).tar.gz)" >> $GITHUB_ENV
         shell: bash
 
       - name: Download artifact ⏬

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -333,7 +333,7 @@ jobs:
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Get package name 📦
-        if: ! startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') == false
         run: |
           echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION)_"\
           "$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION).tar.gz)" >> $GITHUB_ENV

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -333,9 +333,20 @@ jobs:
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Get package name 📦
+        if: '!startsWith(github.ref, 'refs/tags/v')'
         run: |
           echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION)_"\
           "$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION).tar.gz)" >> $GITHUB_ENV
+          echo "PKGNAME=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))" >> $GITHUB_ENV
+        shell: bash
+        working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
+
+      - name: Get package name (tags) 📦
+        if: 'startsWith(github.ref, 'refs/tags/v')'
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+          echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))_\
+          ${{ env.RELEASE_VERSION }}.tar.gz" >> $GITHUB_ENV
           echo "PKGNAME=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))" >> $GITHUB_ENV
         shell: bash
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -333,7 +333,7 @@ jobs:
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Get package name 📦
-        if: '!startsWith(github.ref, 'refs/tags/v')'
+        if: ! startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION)_"\
           "$(awk -F: '/Version:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION).tar.gz)" >> $GITHUB_ENV
@@ -342,7 +342,7 @@ jobs:
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Get package name (tags) 📦
-        if: 'startsWith(github.ref, 'refs/tags/v')'
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
           echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))_\

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -344,9 +344,8 @@ jobs:
       - name: Get package name (tags) 📦
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
           echo "PKGBUILD=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))_\
-          ${{ env.RELEASE_VERSION }}.tar.gz" >> $GITHUB_ENV
+          ${GITHUB_REF#refs/*/v}.tar.gz" >> $GITHUB_ENV
           echo "PKGNAME=$(echo $(awk -F: '/Package:/{gsub(/[ ]+/,"") ; print $2}' DESCRIPTION))" >> $GITHUB_ENV
         shell: bash
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}


### PR DESCRIPTION
Closes https://github.com/insightsengineering/idr-tasks/issues/660

Fix an error when the upload of tar.gz package to GitHub release fails.
This was caused by the use of git tag version instead of version from DESCRIPTION.