### PR TITLE
Update lintr

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
 
       - name: Lint Code Base 🧶
-        uses: super-linter/super-linter/slim@v5.3.1
+        uses: super-linter/super-linter/slim@v5
         env:
           LINTER_RULES_PATH: /
           DEFAULT_BRANCH: main

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
 
       - name: Lint Code Base 🧶
-        uses: github/super-linter/slim@v5.3.1
+        uses: super-linter/super-linter/slim@v5.3.1
         env:
           LINTER_RULES_PATH: /
           DEFAULT_BRANCH: main

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -64,7 +64,7 @@ jobs:
         shell: bash
 
       - name: Lint Code Base 🧶
-        uses: github/super-linter/slim@v5
+        uses: github/super-linter/slim@v5.3.1
         env:
           LINTER_RULES_PATH: /
           DEFAULT_BRANCH: main


### PR DESCRIPTION
The https://github.com/insightsengineering/idr-tasks/issues/667 issue still persists.

I think it's because `github/super-linter/slim@v5` uses `ghcr.io/github/super-linter:slim-v5` which has `lintr` 3.0.2.
Maybe we should in turn use `super-linter/super-linter/slim@v5` which uses `ghcr.io/super-linter/super-linter:slim-v5` and has `lintr` 3.1.0?