### PR TITLE
fix: Update action which now uses Node 20

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,8 @@ jobs:
         if: >-
           steps.rc-tag.outputs.is-rc-tag == 'false' ||
             inputs.create-rc-releases == true
-        uses: softprops/action-gh-release@v1
+        # https://github.com/softprops/action-gh-release/pull/406#issuecomment-1934635958
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           body_path: ${{ inputs.package-subdirectory }}/RELEASE_BODY.txt
           token: ${{ steps.github-token.outputs.token }}


### PR DESCRIPTION
To overcome:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: softprops/action-gh-release@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```