### PR TITLE
Do not hardcode the default branch for linter

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -72,7 +72,7 @@ jobs:
         uses: super-linter/super-linter/slim@v5
         env:
           LINTER_RULES_PATH: /
-          DEFAULT_BRANCH: main
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           FILTER_REGEX_EXCLUDE: NEWS.md|design/.*|testthat/_snaps/.*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
Uses the solution described here: https://stackoverflow.com/a/68414395