### PR TITLE
Add concurrency group input to R CMD check workflow

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -170,7 +170,7 @@ on:
         default: ""
       concurrency-group:
         description: |
-          Concurrency group name
+          Concurrency group name in case a calling workflow would like to use multiple instances of this workflow simultaneously.
         required: false
         type: string
         default: ""

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -168,9 +168,15 @@ on:
         required: false
         type: string
         default: ""
+      concurrency-group:
+        description: |
+          Concurrency group name
+        required: false
+        type: string
+        default: ""
 
 concurrency:
-  group: r-cmd-${{ github.event.pull_request.number || github.ref }}
+  group: r-cmd-${{ inputs.concurrency-group }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Add concurrency group input to allow multiple simultaneous instances of R CMD check workflow in a calling workflow (utilized e.g. in TLG Catalog).