### PR TITLE
Use older version of `actions/checkout`

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 1
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/bioccheck.yaml
+++ b/.github/workflows/bioccheck.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -101,7 +101,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/branch-cleanup.yaml
+++ b/.github/workflows/branch-cleanup.yaml
@@ -37,7 +37,7 @@ jobs:
         shell: bash
 
       - name: Checkout Code 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Cleanup branches 🌿
         uses: phpdocker-io/github-actions-delete-abandoned-branches@v1

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -240,7 +240,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -265,7 +265,7 @@ jobs:
           inputs.publish-unit-test-report-gh-pages == true
             && github.event_name != 'pull_request'
         id: checkout-gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           ref: gh-pages
           path: gh-pages
@@ -488,7 +488,7 @@ jobs:
 
       - name: Fetch report from ${{ env.junit_xml_storage }} ⤵️
         if: env.junit_xml_comparison == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           path: ${{ env.junit_xml_storage }}
           fetch-depth: 0
@@ -587,7 +587,7 @@ jobs:
 
       - name: Fetch JUnit XML reports from ${{ env.junit_xml_storage }} ⤵️
         if: steps.check-junit-xml.outputs.files_exists == 'true' && env.junit_xml_comparison == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           path: ${{ env.junit_xml_storage }}
           fetch-depth: 0
@@ -858,7 +858,7 @@ jobs:
 
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Get package build filename 📦
         run: |

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -231,13 +231,13 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           path: ${{ github.event.repository.name }}
-          # repository: ${{ github.event.pull_request.head.repo.full_name }}
-          # fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
 
       - name: Checkout repo 🛎
         uses: actions/checkout@v4
@@ -359,17 +359,17 @@ jobs:
           update.packages()
         shell: Rscript {0}
 
-      - name: Test
-        shell: bash
-        run: |
-          # apt update && apt install -yq tree
-          echo "pwd = $(pwd)"
-          ls -la
-          # tree -a .
-          R -q -e 'packageVersion("git2r")'
-          chmod -R 777 ${{ github.event.repository.name }}
-          ls -la
-          ls -la ${{ github.event.repository.name }}
+      # - name: Test
+      #   shell: bash
+      #   run: |
+      #     # apt update && apt install -yq tree
+      #     echo "pwd = $(pwd)"
+      #     ls -la
+      #     # tree -a .
+      #     R -q -e 'packageVersion("git2r")'
+      #     chmod -R 777 ${{ github.event.repository.name }}
+      #     ls -la
+      #     ls -la ${{ github.event.repository.name }}
 
       - name: Run Staged dependencies 🎦
         if: >-

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -362,12 +362,14 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          apt update && apt install -yq tree
+          # apt update && apt install -yq tree
           echo "pwd = $(pwd)"
           ls -la
-          tree -a .
+          # tree -a .
           R -q -e 'packageVersion("git2r")'
           chmod -R 777 ${{ github.event.repository.name }}
+          ls -la
+          ls -la ${{ github.event.repository.name }}
 
       - name: Run Staged dependencies 🎦
         if: >-

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -198,7 +198,7 @@ jobs:
       matrix:
         config:
           - image: ghcr.io/insightsengineering/rstudio
-            tag: '2024.04.05'
+            tag: latest
     name: ${{ matrix.config.image }}, version ${{ matrix.config.tag }}
     runs-on: ubuntu-latest
     if: >
@@ -379,7 +379,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -359,18 +359,6 @@ jobs:
           update.packages()
         shell: Rscript {0}
 
-      # - name: Test
-      #   shell: bash
-      #   run: |
-      #     # apt update && apt install -yq tree
-      #     echo "pwd = $(pwd)"
-      #     ls -la
-      #     # tree -a .
-      #     R -q -e 'packageVersion("git2r")'
-      #     chmod -R 777 ${{ github.event.repository.name }}
-      #     ls -la
-      #     ls -la ${{ github.event.repository.name }}
-
       - name: Run Staged dependencies 🎦
         if: >-
           env.enable_sd == 'true'

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -365,7 +365,7 @@ jobs:
           apt update && apt install -yq tree
           echo "pwd = $(pwd)"
           ls -la
-          tree .
+          tree -a .
 
       - name: Run Staged dependencies 🎦
         if: >-
@@ -375,7 +375,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
+          path: ${{ github.event.repository.name }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -198,7 +198,7 @@ jobs:
       matrix:
         config:
           - image: ghcr.io/insightsengineering/rstudio
-            tag: latest
+            tag: '2024.04.05'
     name: ${{ matrix.config.image }}, version ${{ matrix.config.tag }}
     runs-on: ubuntu-latest
     if: >

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -352,14 +352,9 @@ jobs:
           key: sd-${{ runner.os }}-${{ github.event.repository.name }}
           path: ~/.staged.dependencies
 
-      - name: Test
-        shell: bash
-        run: |
-          R -q -e 'packageVersion("git2r")'
-
       - name: Update R packages 🗓️
-        # if: >-
-        #   inputs.update-r-packages == true
+        if: >-
+          inputs.update-r-packages == true
         run: |
           update.packages()
         shell: Rscript {0}
@@ -372,6 +367,7 @@ jobs:
           ls -la
           tree -a .
           R -q -e 'packageVersion("git2r")'
+          chmod -R 777 ${{ github.event.repository.name }}
 
       - name: Run Staged dependencies 🎦
         if: >-

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -236,8 +236,8 @@ jobs:
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           path: ${{ github.event.repository.name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
+          # repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # fetch-depth: 0
 
       - name: Checkout repo 🛎
         uses: actions/checkout@v4
@@ -352,9 +352,14 @@ jobs:
           key: sd-${{ runner.os }}-${{ github.event.repository.name }}
           path: ~/.staged.dependencies
 
+      - name: Test
+        shell: bash
+        run: |
+          R -e -q 'packageVersion("git2r")'
+
       - name: Update R packages 🗓️
-        if: >-
-          inputs.update-r-packages == true
+        # if: >-
+        #   inputs.update-r-packages == true
         run: |
           update.packages()
         shell: Rscript {0}
@@ -366,6 +371,7 @@ jobs:
           echo "pwd = $(pwd)"
           ls -la
           tree -a .
+          R -e -q 'packageVersion("git2r")'
 
       - name: Run Staged dependencies 🎦
         if: >-

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -355,7 +355,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          R -e -q 'packageVersion("git2r")'
+          R -q -e 'packageVersion("git2r")'
 
       - name: Update R packages 🗓️
         # if: >-
@@ -371,7 +371,7 @@ jobs:
           echo "pwd = $(pwd)"
           ls -la
           tree -a .
-          R -e -q 'packageVersion("git2r")'
+          R -q -e 'packageVersion("git2r")'
 
       - name: Run Staged dependencies 🎦
         if: >-

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -359,6 +359,14 @@ jobs:
           update.packages()
         shell: Rscript {0}
 
+      - name: Test
+        shell: bash
+        run: |
+          apt update && apt install -yq tree
+          echo "pwd = $(pwd)"
+          ls -la
+          tree .
+
       - name: Run Staged dependencies 🎦
         if: >-
           env.enable_sd == 'true'

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -45,14 +45,14 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -103,7 +103,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -111,7 +111,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/grammar.yaml
+++ b/.github/workflows/grammar.yaml
@@ -44,14 +44,14 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/licenses.yaml
+++ b/.github/workflows/licenses.yaml
@@ -39,14 +39,14 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -39,14 +39,14 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -121,14 +121,14 @@ jobs:
 
     steps:
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -160,7 +160,7 @@ jobs:
         shell: bash
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -168,7 +168,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -243,7 +243,7 @@ jobs:
 
       - name: Checkout gh-pages 🛎
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           path: "gh-pages"
           fetch-depth: 0
@@ -300,7 +300,7 @@ jobs:
         && !contains(github.event.commits[0].message, '[skip docs]')
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           path: ${{ github.event.repository.name }}
           ref: "gh-pages"
@@ -336,7 +336,7 @@ jobs:
         && !contains(github.event.commits[0].message, '[skip docs]')
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Download artifact ⏬
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Check commit message 💬
         run: |

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -122,6 +122,7 @@ jobs:
           ls -la
           tree -a .
           R -q -e 'packageVersion("git2r")'
+          chmod -R 777 ${{ github.event.repository.name }}
 
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -114,18 +114,6 @@ jobs:
           key: sd-${{ runner.os }}-${{ github.event.repository.name }}
           path: ~/.staged.dependencies
 
-      # - name: Test
-      #   shell: bash
-      #   run: |
-      #     # apt update && apt install -yq tree
-      #     echo "pwd = $(pwd)"
-      #     ls -la
-      #     # tree -a .
-      #     R -q -e 'packageVersion("git2r")'
-      #     chmod -R 777 ${{ github.event.repository.name }}
-      #     ls -la
-      #     ls -la ${{ github.event.repository.name }}
-
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1
         env:

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -84,8 +84,8 @@ jobs:
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           path: ${{ github.event.repository.name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ steps.github-token.outputs.token }}
+          # repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # token: ${{ steps.github-token.outputs.token }}
 
       - name: Checkout repo 🛎
         uses: actions/checkout@v4
@@ -121,6 +121,7 @@ jobs:
           echo "pwd = $(pwd)"
           ls -la
           tree -a .
+          R -e -q 'packageVersion("git2r")'
 
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -88,7 +88,7 @@ jobs:
           token: ${{ steps.github-token.outputs.token }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -59,7 +59,7 @@ jobs:
       !contains(github.event.commits[0].message, '[skip roxygen]')
         && github.event.pull_request.draft == false
     container:
-      image: ghcr.io/insightsengineering/rstudio:latest
+      image: ghcr.io/insightsengineering/rstudio:2024.04.05
 
     steps:
       - name: Setup token 🔑

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -117,12 +117,14 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          apt update && apt install -yq tree
+          # apt update && apt install -yq tree
           echo "pwd = $(pwd)"
           ls -la
-          tree -a .
+          # tree -a .
           R -q -e 'packageVersion("git2r")'
           chmod -R 777 ${{ github.event.repository.name }}
+          ls -la
+          ls -la ${{ github.event.repository.name }}
 
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -120,14 +120,14 @@ jobs:
           apt update && apt install -yq tree
           echo "pwd = $(pwd)"
           ls -la
-          tree .
+          tree -a .
 
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
+          path: ${{ github.event.repository.name }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -79,13 +79,13 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           path: ${{ github.event.repository.name }}
-          # repository: ${{ github.event.pull_request.head.repo.full_name }}
-          # token: ${{ steps.github-token.outputs.token }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ steps.github-token.outputs.token }}
 
       - name: Checkout repo 🛎
         uses: actions/checkout@v4
@@ -114,17 +114,17 @@ jobs:
           key: sd-${{ runner.os }}-${{ github.event.repository.name }}
           path: ~/.staged.dependencies
 
-      - name: Test
-        shell: bash
-        run: |
-          # apt update && apt install -yq tree
-          echo "pwd = $(pwd)"
-          ls -la
-          # tree -a .
-          R -q -e 'packageVersion("git2r")'
-          chmod -R 777 ${{ github.event.repository.name }}
-          ls -la
-          ls -la ${{ github.event.repository.name }}
+      # - name: Test
+      #   shell: bash
+      #   run: |
+      #     # apt update && apt install -yq tree
+      #     echo "pwd = $(pwd)"
+      #     ls -la
+      #     # tree -a .
+      #     R -q -e 'packageVersion("git2r")'
+      #     chmod -R 777 ${{ github.event.repository.name }}
+      #     ls -la
+      #     ls -la ${{ github.event.repository.name }}
 
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -114,6 +114,14 @@ jobs:
           key: sd-${{ runner.os }}-${{ github.event.repository.name }}
           path: ~/.staged.dependencies
 
+      - name: Test
+        shell: bash
+        run: |
+          apt update && apt install -yq tree
+          echo "pwd = $(pwd)"
+          ls -la
+          tree .
+
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1
         env:

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -59,7 +59,7 @@ jobs:
       !contains(github.event.commits[0].message, '[skip roxygen]')
         && github.event.pull_request.draft == false
     container:
-      image: ghcr.io/insightsengineering/rstudio:2024.04.05
+      image: ghcr.io/insightsengineering/rstudio:latest
 
     steps:
       - name: Setup token 🔑
@@ -131,7 +131,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -121,7 +121,7 @@ jobs:
           echo "pwd = $(pwd)"
           ls -la
           tree -a .
-          R -e -q 'packageVersion("git2r")'
+          R -q -e 'packageVersion("git2r")'
 
       - name: Run Staged dependencies 🎦
         uses: insightsengineering/staged-dependencies-action@v1

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -72,7 +72,7 @@ jobs:
           token: ${{ steps.github-token.outputs.token }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -74,7 +74,7 @@ jobs:
           token: ${{ steps.github-token.outputs.token }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -213,7 +213,7 @@ jobs:
           echo "pwd = $(pwd)"
           ls -la
           tree -a .
-          R -e -q 'packageVersion("git2r")'
+          R -q -e 'packageVersion("git2r")'
 
       - name: Restore SD cache 💰
         uses: actions/cache@v4

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -167,12 +167,12 @@ jobs:
         shell: bash
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           path: ${{ github.event.repository.name }}
-          # repository: ${{ github.event.pull_request.head.repo.full_name }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
         uses: actions/checkout@v4
@@ -206,17 +206,17 @@ jobs:
           }
           fi
 
-      - name: Test
-        shell: bash
-        run: |
-          # apt update && apt install -yq tree
-          echo "pwd = $(pwd)"
-          ls -la
-          # tree -a .
-          R -q -e 'packageVersion("git2r")'
-          chmod -R 777 ${{ github.event.repository.name }}
-          ls -la
-          ls -la ${{ github.event.repository.name }}
+      # - name: Test
+      #   shell: bash
+      #   run: |
+      #     # apt update && apt install -yq tree
+      #     echo "pwd = $(pwd)"
+      #     ls -la
+      #     # tree -a .
+      #     R -q -e 'packageVersion("git2r")'
+      #     chmod -R 777 ${{ github.event.repository.name }}
+      #     ls -la
+      #     ls -la ${{ github.event.repository.name }}
 
       - name: Restore SD cache 💰
         uses: actions/cache@v4

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -101,7 +101,7 @@ jobs:
       !contains(github.event.commits[0].message, '[skip coverage]')
         && github.event.pull_request.draft == false
     container:
-      image: ghcr.io/insightsengineering/rstudio:2024.04.05
+      image: ghcr.io/insightsengineering/rstudio:latest
     outputs:
       publish-coverage-html-report: ${{ steps.coverage-output.outputs.coverage-upload }}
       current-branch-or-tag: ${{ steps.current-branch-or-tag.outputs.ref-name }}
@@ -229,7 +229,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.REPO_GITHUB_TOKEN }}
         with:
-          path: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -212,7 +212,7 @@ jobs:
           apt update && apt install -yq tree
           echo "pwd = $(pwd)"
           ls -la
-          tree .
+          tree -a .
 
       - name: Restore SD cache 💰
         uses: actions/cache@v4
@@ -225,7 +225,7 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.REPO_GITHUB_TOKEN }}
         with:
-          path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
+          path: ${{ github.event.repository.name }}
           enable-check: ${{ inputs.enable-staged-dependencies-check }}
           run-system-dependencies: ${{ inputs.install-system-dependencies }}
           direction: ${{ inputs.sd-direction }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -172,7 +172,7 @@ jobs:
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           path: ${{ github.event.repository.name }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
         uses: actions/checkout@v4
@@ -213,6 +213,7 @@ jobs:
           echo "pwd = $(pwd)"
           ls -la
           tree -a .
+          R -e -q 'packageVersion("git2r")'
 
       - name: Restore SD cache 💰
         uses: actions/cache@v4

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -101,7 +101,7 @@ jobs:
       !contains(github.event.commits[0].message, '[skip coverage]')
         && github.event.pull_request.draft == false
     container:
-      image: ghcr.io/insightsengineering/rstudio:latest
+      image: ghcr.io/insightsengineering/rstudio:2024.04.05
     outputs:
       publish-coverage-html-report: ${{ steps.coverage-output.outputs.coverage-upload }}
       current-branch-or-tag: ${{ steps.current-branch-or-tag.outputs.ref-name }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -214,6 +214,7 @@ jobs:
           ls -la
           tree -a .
           R -q -e 'packageVersion("git2r")'
+          chmod -R 777 ${{ github.event.repository.name }}
 
       - name: Restore SD cache 💰
         uses: actions/cache@v4

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -206,18 +206,6 @@ jobs:
           }
           fi
 
-      # - name: Test
-      #   shell: bash
-      #   run: |
-      #     # apt update && apt install -yq tree
-      #     echo "pwd = $(pwd)"
-      #     ls -la
-      #     # tree -a .
-      #     R -q -e 'packageVersion("git2r")'
-      #     chmod -R 777 ${{ github.event.repository.name }}
-      #     ls -la
-      #     ls -la ${{ github.event.repository.name }}
-
       - name: Restore SD cache 💰
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -209,12 +209,14 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          apt update && apt install -yq tree
+          # apt update && apt install -yq tree
           echo "pwd = $(pwd)"
           ls -la
-          tree -a .
+          # tree -a .
           R -q -e 'packageVersion("git2r")'
           chmod -R 777 ${{ github.event.repository.name }}
+          ls -la
+          ls -la ${{ github.event.repository.name }}
 
       - name: Restore SD cache 💰
         uses: actions/cache@v4

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -131,7 +131,7 @@ jobs:
           github.event_name != 'pull_request'
             && inputs.publish-coverage-report-gh-pages == true
         id: checkout-gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           ref: gh-pages
           path: gh-pages
@@ -175,7 +175,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -333,7 +333,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -341,7 +341,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -206,6 +206,14 @@ jobs:
           }
           fi
 
+      - name: Test
+        shell: bash
+        run: |
+          apt update && apt install -yq tree
+          echo "pwd = $(pwd)"
+          ls -la
+          tree .
+
       - name: Restore SD cache 💰
         uses: actions/cache@v4
         with:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -79,14 +79,14 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -148,7 +148,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Download artifact ⏬
         uses: actions/download-artifact@v4

--- a/.github/workflows/verdepcheck.yaml
+++ b/.github/workflows/verdepcheck.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           fetch-depth: 1

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           token: ${{ steps.github-token.outputs.token }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -40,14 +40,14 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
@@ -103,14 +103,14 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - name: Checkout repo (PR) 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name == 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         if: github.event_name != 'pull_request'
         with:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}


### PR DESCRIPTION
[Changes between `actions/checkout@v4.1.1` and `actions/checkout@v4.1.3`](https://github.com/actions/checkout/compare/v4.1.1...v4.1.3) (probably related to sparse checkout) introduced a regression in workflows which use `staged.dependencies`.

The following error occurs in the `Run Staged dependencies` step:
```
Error in git2r::repository(".") : Unable to open repository at 'path'
Calls: <Anonymous> -> <Anonymous>
Execution halted
```
