### PR TITLE
chore: Update the gh-pages action to v4

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -813,7 +813,7 @@ jobs:
 
       - name: Upload JUnit HTML report to GitHub pages 🗞️
         if: needs.build-install-check.outputs.multiversion-docs == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./unit-test-report
@@ -823,7 +823,7 @@ jobs:
         if: >
           needs.build-install-check.outputs.is-latest-tag == 'true'
             && needs.build-install-check.outputs.multiversion-docs == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./unit-test-report
@@ -833,7 +833,7 @@ jobs:
         if: >
           needs.build-install-check.outputs.is-rc-tag == 'true'
             && needs.build-install-check.outputs.multiversion-docs == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./unit-test-report
@@ -841,7 +841,7 @@ jobs:
 
       - name: Upload JUnit HTML report to GitHub pages (non-multiversion) 🗞️
         if: needs.build-install-check.outputs.multiversion-docs == 'false'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./unit-test-report

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -419,7 +419,7 @@ jobs:
 
       - name: Upload coverage report to GitHub pages 🗞️
         if: needs.coverage.outputs.multiversion-docs == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./coverage-report
@@ -429,7 +429,7 @@ jobs:
         if: >
           needs.coverage.outputs.is-latest-tag == 'true'
             && needs.coverage.outputs.multiversion-docs == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./coverage-report
@@ -439,7 +439,7 @@ jobs:
         if: >
           needs.coverage.outputs.is-rc-tag == 'true'
             && needs.coverage.outputs.multiversion-docs == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./coverage-report
@@ -447,7 +447,7 @@ jobs:
 
       - name: Upload coverage report to GitHub pages (non-multiversion) 🗞️
         if: needs.coverage.outputs.multiversion-docs == 'false'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ steps.github-token.outputs.token }}
           publish_dir: ./coverage-report


### PR DESCRIPTION
This should eliminate the following warnings:

![Screenshot 2024-06-04 at 8 52 26 AM](https://github.com/insightsengineering/r.pkg.template/assets/26552821/d452b293-73b7-46de-923f-1105cd3abce2)
