### PR TITLE
Fix urlchecker

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Check URLs with urlchecker 🔬
         run: |
-          bad_urls <- nrow(print(urlchecker::url_check(".")))
+          bad_urls <- nrow(print(urlchecker::url_check(".", parallel = FALSE)))
           if (bad_urls > 0) {
             stop("Looks like a total of ", bad_urls, " URL(s) were found! Please correct them.")
           }

--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -137,6 +137,7 @@ jobs:
 
       - name: Check URLs with urlchecker 🔬
         run: |
+          # For unexplained reasons, parallel = FALSE is required to prevent some false positives.
           bad_urls <- nrow(print(urlchecker::url_check(".", parallel = FALSE)))
           if (bad_urls > 0) {
             stop("Looks like a total of ", bad_urls, " URL(s) were found! Please correct them.")


### PR DESCRIPTION
`parallel = FALSE` seems to help (for reasons unknown) with errors like `502 Bad Gateway` for https://pharmaverse.slack.com.