### PR TITLE
Pass REPO_GITHUB_TOKEN to R-hub workflow

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -96,12 +96,10 @@ jobs:
           job-config: ${{ matrix.config.job-config }}
 
       - name: Prepare DESCRIPTION file
-        uses: insightsengineering/setup-r-dependencies@gh-access-token-for-rhub-workflow
+        uses: insightsengineering/setup-r-dependencies@main
         with:
           lookup-refs: ${{ inputs.lookup-refs }}
           skip-install: true
-        env:
-          TEST1: "test23489"
 
       - uses: r-hub/actions/setup-deps@v1
         with:
@@ -127,6 +125,18 @@ jobs:
         config: ${{ fromJson(needs.setup.outputs.platforms) }}
 
     steps:
+      - name: Setup token 🔑
+        id: github-token
+        run: |
+          if [ "${{ secrets.REPO_GITHUB_TOKEN }}" == "" ]; then
+            echo "REPO_GITHUB_TOKEN is empty. Substituting it with GITHUB_TOKEN."
+            echo "token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using REPO_GITHUB_TOKEN."
+            echo "token=${{ secrets.REPO_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - uses: r-hub/actions/checkout@v1
 
       - uses: r-hub/actions/setup-r@v1
@@ -150,6 +160,8 @@ jobs:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
           needs: DepsDev,DepsBranch
+        env:
+          GITHUB_PAT: ${{ steps.github-token.outputs.token }}
 
       - uses: r-hub/actions/run-check@v1
         with:

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -79,10 +79,12 @@ jobs:
           job-config: ${{ matrix.config.job-config }}
 
       - name: Prepare DESCRIPTION file
-        uses: insightsengineering/setup-r-dependencies@main
+        uses: insightsengineering/setup-r-dependencies@gh-access-token-for-rhub-workflow
         with:
           lookup-refs: ${{ inputs.lookup-refs }}
           skip-install: true
+        env:
+          TEST1: "test23489"
 
       - uses: r-hub/actions/setup-deps@v1
         with:

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -6,6 +6,11 @@ name: R-hub 🌐
 
 on:
   workflow_call:
+    secrets:
+      REPO_GITHUB_TOKEN:
+        description: |
+          Github token with read access to repositories
+        required: false
     inputs:
       config:
         description: 'A comma separated list of R-hub platforms to use.'
@@ -71,6 +76,18 @@ jobs:
       image: ${{ matrix.config.container }}
 
     steps:
+      - name: Setup token 🔑
+        id: github-token
+        run: |
+          if [ "${{ secrets.REPO_GITHUB_TOKEN }}" == "" ]; then
+            echo "REPO_GITHUB_TOKEN is empty. Substituting it with GITHUB_TOKEN."
+            echo "token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using REPO_GITHUB_TOKEN."
+            echo "token=${{ secrets.REPO_GITHUB_TOKEN }}" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       - uses: r-hub/actions/checkout@v1
 
       - uses: r-hub/actions/platform-info@v1
@@ -91,6 +108,8 @@ jobs:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
           needs: DepsDev,DepsBranch
+        env:
+          GITHUB_PAT: ${{ steps.github-token.outputs.token }}
 
       - uses: r-hub/actions/run-check@v1
         with:

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -92,7 +92,6 @@ jobs:
 
       - uses: r-hub/actions/platform-info@v1
         with:
-          token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
 
       - name: Prepare DESCRIPTION file
@@ -103,7 +102,6 @@ jobs:
 
       - uses: r-hub/actions/setup-deps@v1
         with:
-          token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
           needs: DepsDev,DepsBranch
         env:
@@ -111,7 +109,6 @@ jobs:
 
       - uses: r-hub/actions/run-check@v1
         with:
-          token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
 
   other-platforms:
@@ -142,11 +139,9 @@ jobs:
       - uses: r-hub/actions/setup-r@v1
         with:
           job-config: ${{ matrix.config.job-config }}
-          token: ${{ secrets.RHUB_TOKEN }}
 
       - uses: r-hub/actions/platform-info@v1
         with:
-          token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
 
       - name: Setup R dependencies
@@ -158,7 +153,6 @@ jobs:
       - uses: r-hub/actions/setup-deps@v1
         with:
           job-config: ${{ matrix.config.job-config }}
-          token: ${{ secrets.RHUB_TOKEN }}
           needs: DepsDev,DepsBranch
         env:
           GITHUB_PAT: ${{ steps.github-token.outputs.token }}
@@ -166,4 +160,3 @@ jobs:
       - uses: r-hub/actions/run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}
-          token: ${{ secrets.RHUB_TOKEN }}


### PR DESCRIPTION
To prevent GitHub rate-limiting errors during dependency installation in the R-hub workflow.