### PR TITLE
Skip quarto install for rhub workflow

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -96,7 +96,7 @@ jobs:
         with:
           job-config: ${{ matrix.config.job-config }}
 
-      - uses: insightsengineering/setup-r-dependencies@install_quarto_param
+      - uses: insightsengineering/setup-r-dependencies@v1
         with:
           lookup-refs: ${{ inputs.lookup-refs }}
           skip-install: true
@@ -148,7 +148,7 @@ jobs:
         with:
           job-config: ${{ matrix.config.job-config }}
 
-      - uses: insightsengineering/setup-r-dependencies@install_quarto_param
+      - uses: insightsengineering/setup-r-dependencies@v1
         with:
           lookup-refs: ${{ inputs.lookup-refs }}
           skip-install: true

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -154,6 +154,7 @@ jobs:
           skip-install: true
           github-token: ${{ steps.github-token.outputs.token }}
           restore-description: false
+          install-quarto: "false"
 
       - uses: r-hub/actions/setup-deps@v1
         with:

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -148,7 +148,7 @@ jobs:
         with:
           job-config: ${{ matrix.config.job-config }}
 
-      - uses: insightsengineering/setup-r-dependencies@v1
+      - uses: insightsengineering/setup-r-dependencies@install_quarto_param
         with:
           lookup-refs: ${{ inputs.lookup-refs }}
           skip-install: true

--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -96,12 +96,13 @@ jobs:
         with:
           job-config: ${{ matrix.config.job-config }}
 
-      - uses: insightsengineering/setup-r-dependencies@v1
+      - uses: insightsengineering/setup-r-dependencies@install_quarto_param
         with:
           lookup-refs: ${{ inputs.lookup-refs }}
           skip-install: true
           github-token: ${{ steps.github-token.outputs.token }}
           restore-description: false
+          install-quarto: "false"
 
       - uses: r-hub/actions/setup-deps@v1
         with:


### PR DESCRIPTION
Some of the machines in Rhub fails badly when installing quarto. We need to skip it (i) during installing pre-requisites and (ii) in rhub itself. For the latter I opened an issue and the author agrees to hard-code the skip. Note it's not done ATM