### PR TITLE
feat: Upgrade the multiversion docs action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -380,7 +380,7 @@ jobs:
         shell: bash
 
       - name: Create and publish docs ↗️
-        uses: insightsengineering/r-pkgdown-multiversion@v2
+        uses: insightsengineering/r-pkgdown-multiversion@v3
         with:
           path: ${{ github.event.repository.name }}
           default-landing-page: ${{ env.default-landing-page }}


### PR DESCRIPTION
Upgrade the multiversion docs action to v3: https://github.com/insightsengineering/r-pkgdown-multiversion/releases/tag/v3.0.0

v3 uses XML parsing to update the docs, which is a major improvement from v2, which used text parsing methods.