### PR TITLE
Update build-check-install.yaml

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -169,7 +169,7 @@ on:
         description: |
           Passed to `insightsengineering/actions/setup-r-dependencies`.
           Used only if deps-installation-method == 'setup-r-dependencies'.
-        required: true
+        required: false
         type: string
         default: "1"
       unit-test-report-brand:


### PR DESCRIPTION
make the parameter truly optional

Currently our pipelines are failing because of that: https://github.com/insightsengineering/tern/actions/runs/11680162775