### PR TITLE
feat: Add option to disable package rebuilds and uploads

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -241,6 +241,11 @@ on:
         required: false
         type: string
         default: "unit-test-report"
+      disable-package-rebuild-and-upload:
+        description: This will disable the package rebuild and upload step for versioned tags.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: r-cmd-${{ inputs.concurrency-group }}-${{ github.event.pull_request.number || github.ref }}
@@ -836,7 +841,8 @@ jobs:
         if: >
           (inputs.disable-unit-test-reports != 'true' ||
             startsWith(github.ref, 'refs/tags/v')) &&
-            github.event_name != 'pull_request'
+            github.event_name != 'pull_request' &&
+            inputs.disable-package-rebuild-and-upload != 'true'
         run: |
           # Undo changes to DESCRIPTION and tests/testthat.R
           git checkout DESCRIPTION
@@ -854,7 +860,9 @@ jobs:
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 
       - name: Upload package build ⤴
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: >
+          startsWith(github.ref, 'refs/tags/v') &&
+            inputs.disable-package-rebuild-and-upload != 'true'
         uses: actions/upload-artifact@v4
         with:
           path: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}/${{ env.PKGBUILD }}


### PR DESCRIPTION
This adds an option to disable package rebuilds and uploads for release events (aka when a tag is created).

Example sage:

```yaml
jobs:
  r-cmd:
    name: R CMD Check 🧬
    uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
    with:
      # Disable rebuild and upload
      disable-package-rebuild-and-upload: true
```