### PR TITLE
fix: Move rebuild condition inside shell

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -841,8 +841,7 @@ jobs:
         if: >
           (inputs.disable-unit-test-reports != 'true' ||
             startsWith(github.ref, 'refs/tags/v')) &&
-            github.event_name != 'pull_request' &&
-            inputs.disable-package-rebuild-and-upload != 'true'
+            github.event_name != 'pull_request'
         run: |
           # Undo changes to DESCRIPTION and tests/testthat.R
           git checkout DESCRIPTION
@@ -855,7 +854,13 @@ jobs:
             export $(tr '\n' ' ' < /tmp/dotenv.env)
           }
           fi
-          R CMD build .
+          if [ "${{ inputs.disable-package-rebuild-and-upload }}" != "true" ]
+          then {
+            R CMD build .
+          } else {
+            echo "🙅🏼‍♀️ Not rebuilding package for uploads"
+          }
+          fi
         shell: bash
         working-directory: ${{ github.event.repository.name }}/${{ inputs.package-subdirectory }}
 


### PR DESCRIPTION
That way the step condition evaluation that takes place via JavaScript is less complex and less dependent on the type of event.
