### PR TITLE
Add a blocking note for missing VignetteBuilder engine

### DIFF
--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -63,7 +63,7 @@ on:
             checking for unstated dependencies in vignettes ... NOTE( )+\'.*\' import not declared from
             checking dependencies in R code ... NOTE( )+Namespace in Imports field not imported from
             checking installed package size ... NOTE( )+installed size is
-            Files named as vignettes but with no recognized vignette engine.+(Is a VignetteBuilder field missing?)
+            checking files in ‘vignettes’ ... NOTE( )+VignetteBuilder field missing
         required: false
         default: ""
         type: string

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -63,6 +63,7 @@ on:
             checking for unstated dependencies in vignettes ... NOTE( )+\'.*\' import not declared from
             checking dependencies in R code ... NOTE( )+Namespace in Imports field not imported from
             checking installed package size ... NOTE( )+installed size is
+            Files named as vignettes but with no recognized vignette engine.+(Is a VignetteBuilder field missing?)
         required: false
         default: ""
         type: string

--- a/.github/workflows/check.yaml.shared
+++ b/.github/workflows/check.yaml.shared
@@ -38,6 +38,7 @@ jobs:
         checking Rd .usage sections .* NOTE
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
+        checking files in ‘vignettes’ .* NOTE
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -58,6 +59,7 @@ jobs:
         checking Rd .usage sections .* NOTE
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
+        checking files in ‘vignettes’ .* NOTE
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main

--- a/.github/workflows/release.yaml.shared
+++ b/.github/workflows/release.yaml.shared
@@ -44,6 +44,7 @@ jobs:
         checking examples .* NOTE
         checking Rd line widths .* NOTE
         checking top-level files .* NOTE
+        checking files in ‘vignettes’ .* NOTE
   coverage:
     name: Coverage 📔
     needs: [release, docs]


### PR DESCRIPTION
# Pull Request

Following https://github.com/insightsengineering/teal.reporter/issues/288 this PR add this note as a blocking note.

I added the note to several workflows (based on a [PR on other repositories](https://github.com/insightsengineering/teal.reporter/pull/291)), let me know if this is a good approach. 