### PR TITLE
Change deps-installation-method default to setup-r-dependencies

### DIFF
--- a/.github/workflows/bioccheck.yaml
+++ b/.github/workflows/bioccheck.yaml
@@ -60,7 +60,7 @@ on:
           setup-r-dependencies
         required: false
         type: string
-        default: staged-dependencies
+        default: setup-r-dependencies
       lookup-refs:
         description: |
           List of package references to be used by setup-r-dependencies action if deps-installation-method == 'setup-r-dependencies'.

--- a/.github/workflows/build-check-install.yaml
+++ b/.github/workflows/build-check-install.yaml
@@ -143,7 +143,7 @@ on:
           setup-r-dependencies
         required: false
         type: string
-        default: staged-dependencies
+        default: setup-r-dependencies
       lookup-refs:
         description: |
           List of package references to be used by setup-r-dependencies action if deps-installation-method == 'setup-r-dependencies'.

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -133,7 +133,7 @@ on:
           setup-r-dependencies
         required: false
         type: string
-        default: staged-dependencies
+        default: setup-r-dependencies
       lookup-refs:
         description: |
           List of package references to be used by setup-r-dependencies action if deps-installation-method == 'setup-r-dependencies'.

--- a/.github/workflows/roxygen.yaml
+++ b/.github/workflows/roxygen.yaml
@@ -48,7 +48,7 @@ on:
           setup-r-dependencies
         required: false
         type: string
-        default: staged-dependencies
+        default: setup-r-dependencies
       lookup-refs:
         description: |
           Passed to insightsengineering/setup-r-dependencies. See its documentation.

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -89,7 +89,7 @@ on:
           setup-r-dependencies
         required: false
         type: string
-        default: staged-dependencies
+        default: setup-r-dependencies
       lookup-refs:
         description: |
           List of package references to be used by setup-r-dependencies action if deps-installation-method == 'setup-r-dependencies'.

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -45,7 +45,7 @@ on:
           setup-r-dependencies
         required: false
         type: string
-        default: staged-dependencies
+        default: setup-r-dependencies
       lookup-refs:
         description: |
           List of package references to be used by setup-r-dependencies action if deps-installation-method == 'setup-r-dependencies'.


### PR DESCRIPTION
# Pull Request

Changes the default deps-installation-method to setup-r-dependencies

I noticed that in some circumstances it didn't pick the right CRAN versions.

[most repos using these actions](https://github.com/search?q=%22insightsengineering%2Fr.pkg.template%2F.github%2Fworkflows%2F%22+path%3A.github%2Fworkflows%2F*.yaml&type=code) [already use setup-r-dependencies as an option](https://github.com/search?q=deps-installation-method+path%3A.github%2Fworkflows%2F*.yaml&type=code) (144/179), including new packages like https://github.com/phuse-org/uteals and old like rtables